### PR TITLE
Fix JsonDocumentTransformer.bind for dart 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.4+1
+## 1.6.5
 
 * Fix an issue with `JsonDocumentTransformer.bind` where it created an internal
   stream channel which didn't get a properly inferred type for its `sink`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.4+1
+
+* Fix an issue with `JsonDocumentTransformer.bind` where it created an internal
+  stream channel which didn't get a properly inferred type for its `sink`.
+
 ## 1.6.4
 
 * Fix a race condition in `MultiChannel` where messages from a remote virtual

--- a/lib/src/json_document_transformer.dart
+++ b/lib/src/json_document_transformer.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:async/async.dart';
@@ -35,9 +36,10 @@ class JsonDocumentTransformer
 
   JsonDocumentTransformer._(this._codec);
 
-  StreamChannel bind(StreamChannel<String> channel) {
+  StreamChannel<Object> bind(StreamChannel<String> channel) {
     var stream = channel.stream.map(_codec.decode);
-    var sink = new StreamSinkTransformer.fromHandlers(handleData: (data, sink) {
+    var sink = new StreamSinkTransformer.fromHandlers(
+        handleData: (Object data, EventSink<String> sink) {
       sink.add(_codec.encode(data));
     }).bind(channel.sink);
     return new StreamChannel.withCloseGuarantee(stream, sink);

--- a/lib/src/json_document_transformer.dart
+++ b/lib/src/json_document_transformer.dart
@@ -38,8 +38,8 @@ class JsonDocumentTransformer
 
   StreamChannel<Object> bind(StreamChannel<String> channel) {
     var stream = channel.stream.map(_codec.decode);
-    var sink = new StreamSinkTransformer.fromHandlers(
-        handleData: (Object data, EventSink<String> sink) {
+    var sink = new StreamSinkTransformer<Object, String>.fromHandlers(
+        handleData: (data, sink) {
       sink.add(_codec.encode(data));
     }).bind(channel.sink);
     return new StreamChannel.withCloseGuarantee(stream, sink);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 1.6.4
+version: 1.6.4+5
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/stream_channel

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 1.6.4+1
+version: 1.6.5
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/stream_channel

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 1.6.4+5
+version: 1.6.4+1
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/stream_channel


### PR DESCRIPTION
Previously the local `sink` didn't get its generic type inferred properly and you would get runtime errors on certain operations which are difficult to track down. 