### PR TITLE
Fix a remaining Dart 2 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.6.6
 
-* Fix a Dart2 issue with inner stream transformation in `GuaranteeChannel`.
+* Fix a Dart 2 issue with inner stream transformation in `GuaranteeChannel`.
+
+* Fix a Dart 2 issue with `StreamChannelTransformer.fromCodec()`.
 
 ## 1.6.5
 

--- a/lib/src/stream_channel_transformer.dart
+++ b/lib/src/stream_channel_transformer.dart
@@ -57,11 +57,8 @@ class StreamChannelTransformer<S, T> {
   /// All input to the inner channel's sink is encoded using [Codec.encoder],
   /// and all output from its stream is decoded using [Codec.decoder].
   StreamChannelTransformer.fromCodec(Codec<S, T> codec)
-      : this(
-            typedStreamTransformer(codec.decoder),
-            StreamSinkTransformer.typed(
-                new StreamSinkTransformer.fromStreamTransformer(
-                    codec.encoder)));
+      : this(codec.decoder,
+            new StreamSinkTransformer.fromStreamTransformer(codec.encoder));
 
   /// Transforms the events sent to and emitted by [channel].
   ///

--- a/test/stream_channel_test.dart
+++ b/test/stream_channel_test.dart
@@ -41,8 +41,9 @@ void main() {
   });
 
   test("transform() transforms the channel", () async {
-    var transformed =
-        channel.transform(new StreamChannelTransformer.fromCodec(UTF8));
+    var transformed = channel
+        .cast<List<int>>()
+        .transform(new StreamChannelTransformer.fromCodec(UTF8));
 
     streamController.add([102, 111, 111, 98, 97, 114]);
     streamController.close();


### PR DESCRIPTION
We had some unnecessary typed wrappers that were interfering with
runtime type arguments.

Closes #22