### PR TITLE
Drop dependency on StackTrace

### DIFF
--- a/lib/src/isolate_channel.dart
+++ b/lib/src/isolate_channel.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:async/async.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import '../stream_channel.dart';
 
@@ -66,7 +65,7 @@ class IsolateChannel<T> extends StreamChannelMixin<T> {
 
       streamCompleter.setError(
           new StateError('Unexpected Isolate response "$message".'),
-          new Trace.current());
+          StackTrace.current);
       sinkCompleter.setDestinationSink(new NullStreamSink<T>());
       subscription.cancel();
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,5 @@ environment:
   sdk: '>=2.0.0-dev.17.0 <2.0.0'
 dependencies:
   async: '>=1.11.0 <3.0.0'
-  stack_trace: '^1.0.0'
 dev_dependencies:
   test: '^0.12.28'


### PR DESCRIPTION
The extra wrapping of `StackTrace.current` can always be done by the
receiver.