### PR TITLE
Enable prefer_typing_unitialized_varables lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,3 +10,4 @@ analyzer:
 linter:
   rules:
     - comment_references
+    - prefer_typing_uninitialized_variables

--- a/lib/src/isolate_channel.dart
+++ b/lib/src/isolate_channel.dart
@@ -49,7 +49,7 @@ class IsolateChannel<T> extends StreamChannelMixin<T> {
     // The first message across the ReceivePort should be a SendPort pointing to
     // the remote end. If it's not, we'll make the stream emit an error
     // complaining.
-    var subscription;
+    StreamSubscription<T> subscription;
     subscription = receivePort.listen((message) {
       if (message is SendPort) {
         var controller = new StreamChannelController<T>(

--- a/lib/src/multi_channel.dart
+++ b/lib/src/multi_channel.dart
@@ -72,7 +72,7 @@ abstract class MultiChannel<T> implements StreamChannel<T> {
   ///
   /// Throws an [ArgumentError] if a virtual channel already exists for [id].
   /// Throws a [StateError] if the underlying channel is closed.
-  VirtualChannel<T> virtualChannel([id]);
+  VirtualChannel<T> virtualChannel([int id]);
 }
 
 /// The implementation of [MultiChannel].
@@ -166,15 +166,15 @@ class _MultiChannel<T> extends StreamChannelMixin<T>
         onError: _mainController.local.sink.addError);
   }
 
-  VirtualChannel<T> virtualChannel([id]) {
-    var inputId;
-    var outputId;
+  VirtualChannel<T> virtualChannel([int id]) {
+    int inputId;
+    int outputId;
     if (id != null) {
       // Since the user is passing in an id, we're connected to a remote
       // VirtualChannel. This means messages they send over this channel will
       // have the original odd id, but our replies will have an even id.
       inputId = id;
-      outputId = (id as int) + 1;
+      outputId = id + 1;
     } else {
       // Since we're generating an id, we originated this VirtualChannel. This
       // means messages we send over this channel will have the original odd id,
@@ -256,7 +256,7 @@ class VirtualChannel<T> extends StreamChannelMixin<T>
   /// This can be sent across the [MultiChannel] to provide the remote endpoint
   /// a means to connect to this channel. Nothing about this is guaranteed
   /// except that it will be JSON-serializable.
-  final id;
+  final int id;
 
   final Stream<T> stream;
   final StreamSink<T> sink;

--- a/test/disconnector_test.dart
+++ b/test/disconnector_test.dart
@@ -9,10 +9,10 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var streamController;
-  var sinkController;
-  var disconnector;
-  var channel;
+  StreamController streamController;
+  StreamController sinkController;
+  Disconnector disconnector;
+  StreamChannel channel;
   setUp(() {
     streamController = new StreamController();
     sinkController = new StreamController();

--- a/test/isolate_channel_test.dart
+++ b/test/isolate_channel_test.dart
@@ -11,9 +11,9 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var receivePort;
-  var sendPort;
-  var channel;
+  ReceivePort receivePort;
+  SendPort sendPort;
+  StreamChannel channel;
   setUp(() {
     receivePort = new ReceivePort();
     var receivePortForSend = new ReceivePort();
@@ -126,7 +126,7 @@ void main() {
   });
 
   group("connect constructors", () {
-    var connectPort;
+    ReceivePort connectPort;
     setUp(() {
       connectPort = new ReceivePort();
     });

--- a/test/json_document_transformer_test.dart
+++ b/test/json_document_transformer_test.dart
@@ -9,8 +9,8 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var streamController;
-  var sinkController;
+  StreamController<String> streamController;
+  StreamController<String> sinkController;
   StreamChannel<String> channel;
   setUp(() {
     streamController = new StreamController<String>();

--- a/test/multi_channel_test.dart
+++ b/test/multi_channel_test.dart
@@ -6,9 +6,9 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var controller;
-  var channel1;
-  var channel2;
+  StreamChannelController controller;
+  MultiChannel channel1;
+  MultiChannel channel2;
   setUp(() {
     controller = new StreamChannelController();
     channel1 = new MultiChannel<int>(controller.local);
@@ -84,8 +84,8 @@ void main() {
   });
 
   group("a locally-created virtual channel", () {
-    var virtual1;
-    var virtual2;
+    VirtualChannel virtual1;
+    VirtualChannel virtual2;
     setUp(() {
       virtual1 = channel1.virtualChannel();
       virtual2 = channel2.virtualChannel(virtual1.id);
@@ -184,8 +184,8 @@ void main() {
   });
 
   group("a remotely-created virtual channel", () {
-    var virtual1;
-    var virtual2;
+    VirtualChannel virtual1;
+    VirtualChannel virtual2;
     setUp(() {
       virtual1 = channel1.virtualChannel();
       virtual2 = channel2.virtualChannel(virtual1.id);
@@ -296,8 +296,8 @@ void main() {
   });
 
   group("when the underlying stream", () {
-    var virtual1;
-    var virtual2;
+    VirtualChannel virtual1;
+    VirtualChannel virtual2;
     setUp(() {
       virtual1 = channel1.virtualChannel();
       virtual2 = channel2.virtualChannel(virtual1.id);
@@ -405,8 +405,8 @@ void main() {
     });
 
     group("for a virtual channel:", () {
-      var virtual1;
-      var virtual2;
+      VirtualChannel virtual1;
+      VirtualChannel virtual2;
       setUp(() {
         virtual1 = channel1.virtualChannel();
         virtual2 = channel2.virtualChannel(virtual1.id);

--- a/test/stream_channel_completer_test.dart
+++ b/test/stream_channel_completer_test.dart
@@ -8,10 +8,10 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var completer;
-  var streamController;
-  var sinkController;
-  var innerChannel;
+  StreamChannelCompleter completer;
+  StreamController streamController;
+  StreamController sinkController;
+  StreamChannel innerChannel;
   setUp(() {
     completer = new StreamChannelCompleter();
     streamController = new StreamController();

--- a/test/stream_channel_controller_test.dart
+++ b/test/stream_channel_controller_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 void main() {
   group("asynchronously", () {
-    var controller;
+    StreamChannelController controller;
     setUp(() {
       controller = new StreamChannelController();
     });
@@ -44,7 +44,7 @@ void main() {
   });
 
   group("synchronously", () {
-    var controller;
+    StreamChannelController controller;
     setUp(() {
       controller = new StreamChannelController(sync: true);
     });

--- a/test/with_close_guarantee_test.dart
+++ b/test/with_close_guarantee_test.dart
@@ -16,8 +16,8 @@ final _delaySinkTransformer =
     new StreamSinkTransformer.fromStreamTransformer(_delayTransformer);
 
 void main() {
-  var controller;
-  var channel;
+  StreamChannelController controller;
+  StreamChannel channel;
   setUp(() {
     controller = new StreamChannelController();
 

--- a/test/with_guarantees_test.dart
+++ b/test/with_guarantees_test.dart
@@ -8,9 +8,9 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var streamController;
-  var sinkController;
-  var channel;
+  StreamController streamController;
+  StreamController sinkController;
+  StreamChannel channel;
   setUp(() {
     streamController = new StreamController();
     sinkController = new StreamController();


### PR DESCRIPTION
Fixes #29

Using the lint catches a bug were an uninitialized variable was causing
an intantiation to pick up a reified type of `dynamic` instead of a
useful type.