### PR TITLE
Cast streams to correct types in IsolateChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.7+1
+
+* Fix Dart 2 runtime types in `IsolateChannel`.
+
 ## 1.6.7
 
 * Update SDK version to 2.0.0-dev.17.0.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 1.6.7
+version: 1.6.7+1
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/stream_channel

--- a/test/isolate_channel_test.dart
+++ b/test/isolate_channel_test.dart
@@ -135,7 +135,7 @@ void main() {
       connectPort.close();
     });
 
-    test("create a connected pair of channels", () async {
+    test("create a connected pair of channels", () {
       var channel1 = new IsolateChannel<int>.connectReceive(connectPort);
       var channel2 = new IsolateChannel<int>.connectSend(connectPort.sendPort);
 

--- a/test/isolate_channel_test.dart
+++ b/test/isolate_channel_test.dart
@@ -135,9 +135,9 @@ void main() {
       connectPort.close();
     });
 
-    test("create a connected pair of channels", () {
-      var channel1 = new IsolateChannel.connectReceive(connectPort);
-      var channel2 = new IsolateChannel.connectSend(connectPort.sendPort);
+    test("create a connected pair of channels", () async {
+      var channel1 = new IsolateChannel<int>.connectReceive(connectPort);
+      var channel2 = new IsolateChannel<int>.connectSend(connectPort.sendPort);
 
       channel1.sink.add(1);
       channel1.sink.add(2);


### PR DESCRIPTION
Fixes #29

- Add a type on the IsolateChannel in one of the tests so that it
  exhibits the problem when run in Dart 2 mode.
- Cast the streams coming from the ReceivePort instances to the
  appropriate types since ReceivePort is always `Stream<dynamic>`.
- Remove the type on the subscription variable since it's a subscription
  on a dynamic stream and otherwise would never have the correct type.