### PR TITLE
Use a config specific import for IsolateChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+* Use a config specific import for `IsolateChannel`.
+
 ## 1.6.8
 
 * Set max SDK version to `<3.0.0`, and adjust other dependencies.

--- a/lib/src/isolate_channel.dart
+++ b/lib/src/isolate_channel.dart
@@ -38,7 +38,7 @@ class IsolateChannel<T> extends StreamChannelMixin<T> {
   /// at least until the next major version release. If the protocol is
   /// violated, the resulting channel will emit a single value on its stream and
   /// then close.
-  factory IsolateChannel.connectReceive(ReceivePort receivePort) {
+  factory IsolateChannel.connectReceive(dynamic receivePort) {
     // We can't use a [StreamChannelCompleter] here because we need the return
     // value to be an [IsolateChannel].
     var streamCompleter = new StreamCompleter<T>();
@@ -84,7 +84,7 @@ class IsolateChannel<T> extends StreamChannelMixin<T> {
   ///
   /// The connection protocol is guaranteed to remain compatible across versions
   /// at least until the next major version release.
-  factory IsolateChannel.connectSend(SendPort sendPort) {
+  factory IsolateChannel.connectSend(dynamic sendPort) {
     var receivePort = new ReceivePort();
     sendPort.send(receivePort.sendPort);
     return new IsolateChannel(receivePort, sendPort);
@@ -92,7 +92,7 @@ class IsolateChannel<T> extends StreamChannelMixin<T> {
 
   /// Creates a stream channel that receives messages from [receivePort] and
   /// sends them over [sendPort].
-  factory IsolateChannel(ReceivePort receivePort, SendPort sendPort) {
+  factory IsolateChannel(dynamic receivePort, dynamic sendPort) {
     var controller =
         new StreamChannelController<T>(allowForeignErrors: false, sync: true);
     receivePort.cast<T>().pipe(controller.local.sink);

--- a/lib/src/isolate_channel.dart
+++ b/lib/src/isolate_channel.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+// ignore: uri_does_not_exist
 import 'isolate_stub.dart' if (dart.library.isolate) 'dart:isolate';
 
 import 'package:async/async.dart';

--- a/lib/src/isolate_channel.dart
+++ b/lib/src/isolate_channel.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:isolate';
+import 'isolate_stub.dart' if (dart.library.isolate) 'dart:isolate';
 
 import 'package:async/async.dart';
 

--- a/lib/src/isolate_stub.dart
+++ b/lib/src/isolate_stub.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 abstract class ReceivePort implements Stream {
   void close();
 

--- a/lib/src/isolate_stub.dart
+++ b/lib/src/isolate_stub.dart
@@ -1,0 +1,12 @@
+abstract class ReceivePort implements Stream {
+  void close();
+
+  SendPort get sendPort;
+
+  factory ReceivePort() =>
+      throw UnsupportedError('IsolateChannel does not work on this platform');
+}
+
+abstract class SendPort {
+  void send(dynamic data);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: stream_channel
-version: 1.6.8
+version: 1.7.0
 
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/stream_channel
 
 environment:
-  sdk: '>=2.0.0-dev.17.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   async: '>=1.11.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/stream_channel
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.1.1 <3.0.0'
 
 dependencies:
   async: '>=1.11.0 <3.0.0'


### PR DESCRIPTION
Fixes #36

`dart:isolate` may be imported on the web, but not used at runtime.
Since no instance of a real `ReceivePort` or `SendPort` could exist at
runtime on a platform without `dart.library.isolate` it is safe to stub
out the used portion of the API in abstract classes.