### PR TITLE
Move isolate_channel to it's own import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## 1.6.9
+## 2.0.0
 
+* **Breaking change** `IsolateChannel` requires a separate import
+  `package:stram_channel/isolate_channel.dart`.
+  `package:stream_channel/stream_channel.dart` will now not trigger any platform
+  concerns due to importing `dart:isolate`.
 * Require `2.0.0` or newer SDK.
 * Drop unnecessary `new` and `const`.
 

--- a/lib/isolate_channel.dart
+++ b/lib/isolate_channel.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/isolate_channel.dart' show IsolateChannel;

--- a/lib/stream_channel.dart
+++ b/lib/stream_channel.dart
@@ -12,7 +12,6 @@ import 'src/stream_channel_transformer.dart';
 
 export 'src/delegating_stream_channel.dart';
 export 'src/disconnector.dart';
-export 'src/isolate_channel.dart';
 export 'src/json_document_transformer.dart';
 export 'src/multi_channel.dart';
 export 'src/stream_channel_completer.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,3 @@ dependencies:
 
 dev_dependencies:
   test: ^1.2.0
-
-dependency_overrides:
-  test: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 1.6.9
+version: 2.0.0
 
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,3 +13,6 @@ dependencies:
 
 dev_dependencies:
   test: ^1.2.0
+
+dependency_overrides:
+  test: ^1.2.0


### PR DESCRIPTION
Fixes #36 

This allows the default import to work without triggering any warnings
on the web due to transitively importing `dart:isolate`. This is
required to allow restricting imports based on platform.