### PR TITLE
Add separate import for `IsolateChannel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   `package:stream_channel/isolate_channel.dart`. This will be the required
   import in the next release.
 * Require `2.0.0` or newer SDK.
-* Drop unnecessary `new` and `const`.
+* Internal style changes.
 
 ## 1.6.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 1.6.9
+## 1.7.0
 
+* Make `IsolateChannel` available through
+  `package:stream_channel/isolate_channel.dart`. This will be the required
+  import in the next release.
 * Require `2.0.0` or newer SDK.
 * Drop unnecessary `new` and `const`.
 

--- a/lib/isolate_channel.dart
+++ b/lib/isolate_channel.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/isolate_channel.dart' show IsolateChannel;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 1.6.9
+version: 1.7.0
 
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>

--- a/test/isolate_channel_test.dart
+++ b/test/isolate_channel_test.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:isolate';
 
+import 'package:stream_channel/isolate_channel.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
This will allow us to move to this import in the few packages which are
using this class, like test, without having a fully broken state in
between, and without required `git` dependency overrides.