### PR TITLE
Hide JsonDocumentTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## 2.0.0
 
-* **Breaking change** `IsolateChannel` requires a separate import
+**Breaking changes**
+
+* `IsolateChannel` requires a separate import
   `package:stram_channel/isolate_channel.dart`.
   `package:stream_channel/stream_channel.dart` will now not trigger any platform
   concerns due to importing `dart:isolate`.
+* Remove `JsonDocumentTransformer` class. The `jsonDocument` top level is still
+  available.
 
 ## 1.7.0
 

--- a/lib/src/json_document_transformer.dart
+++ b/lib/src/json_document_transformer.dart
@@ -18,11 +18,11 @@ import 'stream_channel_transformer.dart';
 /// If the transformed channel emits invalid JSON, this emits a
 /// [FormatException]. If an unencodable object is added to the sink, it
 /// synchronously throws a [JsonUnsupportedObjectError].
-final jsonDocument = const _JsonDocumentTransformer();
+final StreamChannelTransformer<Object, String> jsonDocument =
+    const _JsonDocument();
 
-class _JsonDocumentTransformer
-    implements StreamChannelTransformer<Object, String> {
-  const _JsonDocumentTransformer();
+class _JsonDocument implements StreamChannelTransformer<Object, String> {
+  const _JsonDocument();
 
   @override
   StreamChannel<Object> bind(StreamChannel<String> channel) {

--- a/lib/src/json_document_transformer.dart
+++ b/lib/src/json_document_transformer.dart
@@ -9,9 +9,6 @@ import 'package:async/async.dart';
 import '../stream_channel.dart';
 import 'stream_channel_transformer.dart';
 
-/// The canonical instance of [JsonDocumentTransformer].
-final jsonDocument = JsonDocumentTransformer();
-
 /// A [StreamChannelTransformer] that transforms JSON documents—strings that
 /// contain individual objects encoded as JSON—into decoded Dart objects.
 ///
@@ -21,26 +18,19 @@ final jsonDocument = JsonDocumentTransformer();
 /// If the transformed channel emits invalid JSON, this emits a
 /// [FormatException]. If an unencodable object is added to the sink, it
 /// synchronously throws a [JsonUnsupportedObjectError].
-class JsonDocumentTransformer
+final jsonDocument = const _JsonDocumentTransformer();
+
+class _JsonDocumentTransformer
     implements StreamChannelTransformer<Object, String> {
-  /// The underlying codec that implements the encoding and decoding logic.
-  final JsonCodec _codec;
 
-  /// Creates a new transformer.
-  ///
-  /// The [reviver] and [toEncodable] arguments work the same way as the
-  /// corresponding arguments to [new JsonCodec].
-  JsonDocumentTransformer({reviver(key, value), toEncodable(object)})
-      : _codec = JsonCodec(reviver: reviver, toEncodable: toEncodable);
-
-  JsonDocumentTransformer._(this._codec);
+  const _JsonDocumentTransformer();
 
   @override
   StreamChannel<Object> bind(StreamChannel<String> channel) {
-    var stream = channel.stream.map(_codec.decode);
+    var stream = channel.stream.map(jsonDecode);
     var sink = StreamSinkTransformer<Object, String>.fromHandlers(
         handleData: (data, sink) {
-      sink.add(_codec.encode(data));
+      sink.add(jsonEncode(data));
     }).bind(channel.sink);
     return StreamChannel.withCloseGuarantee(stream, sink);
   }

--- a/lib/src/json_document_transformer.dart
+++ b/lib/src/json_document_transformer.dart
@@ -22,7 +22,6 @@ final jsonDocument = const _JsonDocumentTransformer();
 
 class _JsonDocumentTransformer
     implements StreamChannelTransformer<Object, String> {
-
   const _JsonDocumentTransformer();
 
   @override

--- a/test/json_document_transformer_test.dart
+++ b/test/json_document_transformer_test.dart
@@ -32,20 +32,6 @@ void main() {
         completion(equals(jsonEncode({"foo": "bar"}))));
   });
 
-  test("supports the reviver function", () {
-    var transformed = channel
-        .transform(JsonDocumentTransformer(reviver: (key, value) => "decoded"));
-    streamController.add('{"foo": "bar"}');
-    expect(transformed.stream.first, completion(equals("decoded")));
-  });
-
-  test("supports the toEncodable function", () {
-    var transformed = channel
-        .transform(JsonDocumentTransformer(toEncodable: (object) => "encoded"));
-    transformed.sink.add(Object());
-    expect(sinkController.stream.first, completion(equals('"encoded"')));
-  });
-
   test("emits a stream error when incoming JSON is malformed", () {
     var transformed = channel.transform(jsonDocument);
     streamController.add("{invalid");


### PR DESCRIPTION
Closes #34

This was only used through the top level variable `jsonDocument` and no
use cases have surfaced for being able to pass a `reviver` or
`toEncodable` callback.

This implementation does no use `StreamChannelTransformer.fromCodec`
with a `JsonCodec` since the encoder and decoder are not 1:1.

- Remove the `JsonCodec` field and use `jsonEncode` and `jsonDecode`
  calls directly.
- Move the detailed doc to `jsonDocument`.
- Make the class private.
- Remove the tests constructing the class directly.