### PR TITLE
Use pedantic lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,4 @@
+include: package:pedantic/analysis_options.yaml
 analyzer:
   # These are errors when building in Google
   errors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 2.0.0
+version: 2.0.1-dev
 
 description: An abstraction for two-way communication channels.
 author: Dart Team <misc@dartlang.org>
@@ -12,4 +12,5 @@ dependencies:
   async: '>=1.11.0 <3.0.0'
 
 dev_dependencies:
+  pedantic: ^1.8.0
   test: ^1.2.0

--- a/test/disconnector_test.dart
+++ b/test/disconnector_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -71,7 +72,7 @@ void main() {
       canceled = true;
     });
     expect(channel.sink.addStream(controller.stream), completes);
-    disconnector.disconnect();
+    unawaited(disconnector.disconnect());
 
     await pumpEventQueue();
     expect(canceled, isTrue);

--- a/test/isolate_channel_test.dart
+++ b/test/isolate_channel_test.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:isolate';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/isolate_channel.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
@@ -82,7 +83,7 @@ void main() {
 
     test("cancelling the stream's subscription has no effect on the sink",
         () async {
-      channel.stream.listen(null).cancel();
+      unawaited(channel.stream.listen(null).cancel());
       await pumpEventQueue();
 
       channel.sink.add(1);

--- a/test/multi_channel_test.dart
+++ b/test/multi_channel_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -143,13 +144,13 @@ void main() {
         "virtual channels", () async {
       // First close the default channel so we can test the new channel as the
       // last living virtual channel.
-      channel1.sink.close();
+      unawaited(channel1.sink.close());
 
       await channel2.stream.toList();
       expect(controller.local.sink.done, completes);
       expect(controller.foreign.sink.done, completes);
 
-      virtual1.sink.close();
+      unawaited(virtual1.sink.close());
     });
 
     test(
@@ -243,13 +244,13 @@ void main() {
         "virtual channels", () async {
       // First close the default channel so we can test the new channel as the
       // last living virtual channel.
-      channel2.sink.close();
+      unawaited(channel2.sink.close());
 
       await channel1.stream.toList();
       expect(controller.local.sink.done, completes);
       expect(controller.foreign.sink.done, completes);
 
-      virtual2.sink.close();
+      unawaited(virtual2.sink.close());
     });
 
     test(
@@ -287,7 +288,7 @@ void main() {
         "created", () async {
       virtual1 = channel1.virtualChannel();
 
-      virtual1.sink.close();
+      unawaited(virtual1.sink.close());
       await pumpEventQueue();
 
       expect(channel2.virtualChannel(virtual1.id).stream.toList(),
@@ -317,8 +318,8 @@ void main() {
     });
 
     test("closes, more virtual channels are created closed", () async {
-      channel2.sink.close();
-      virtual2.sink.close();
+      unawaited(channel2.sink.close());
+      unawaited(virtual2.sink.close());
 
       // Wait for the existing channels to emit done events.
       await channel1.stream.toList();
@@ -359,14 +360,14 @@ void main() {
       });
 
       test("after the stream closes, the sink ignores events", () async {
-        channel1.sink.close();
+        unawaited(channel1.sink.close());
 
         // Wait for the done event to be delivered.
         await channel2.stream.toList();
         channel2.sink.add(1);
         channel2.sink.add(2);
         channel2.sink.add(3);
-        channel2.sink.close();
+        unawaited(channel2.sink.close());
 
         // None of our channel.sink additions should make it to the other endpoint.
         channel1.stream.listen(expectAsync1((_) {}, count: 0));
@@ -375,28 +376,28 @@ void main() {
 
       test("canceling the stream's subscription has no effect on the sink",
           () async {
-        channel1.stream.listen(null).cancel();
+        unawaited(channel1.stream.listen(null).cancel());
         await pumpEventQueue();
 
         channel1.sink.add(1);
         channel1.sink.add(2);
         channel1.sink.add(3);
-        channel1.sink.close();
+        unawaited(channel1.sink.close());
         expect(channel2.stream.toList(), completion(equals([1, 2, 3])));
       });
 
       test("canceling the stream's subscription doesn't stop a done event",
           () async {
-        channel1.stream.listen(null).cancel();
+        unawaited(channel1.stream.listen(null).cancel());
         await pumpEventQueue();
 
-        channel2.sink.close();
+        unawaited(channel2.sink.close());
         await pumpEventQueue();
 
         channel1.sink.add(1);
         channel1.sink.add(2);
         channel1.sink.add(3);
-        channel1.sink.close();
+        unawaited(channel1.sink.close());
 
         // The sink should be ignoring events because the channel closed.
         channel2.stream.listen(expectAsync1((_) {}, count: 0));
@@ -426,14 +427,14 @@ void main() {
       });
 
       test("after the stream closes, the sink ignores events", () async {
-        virtual1.sink.close();
+        unawaited(virtual1.sink.close());
 
         // Wait for the done event to be delivered.
         await virtual2.stream.toList();
         virtual2.sink.add(1);
         virtual2.sink.add(2);
         virtual2.sink.add(3);
-        virtual2.sink.close();
+        unawaited(virtual2.sink.close());
 
         // None of our virtual.sink additions should make it to the other endpoint.
         virtual1.stream.listen(expectAsync1((_) {}, count: 0));
@@ -442,28 +443,28 @@ void main() {
 
       test("canceling the stream's subscription has no effect on the sink",
           () async {
-        virtual1.stream.listen(null).cancel();
+        unawaited(virtual1.stream.listen(null).cancel());
         await pumpEventQueue();
 
         virtual1.sink.add(1);
         virtual1.sink.add(2);
         virtual1.sink.add(3);
-        virtual1.sink.close();
+        unawaited(virtual1.sink.close());
         expect(virtual2.stream.toList(), completion(equals([1, 2, 3])));
       });
 
       test("canceling the stream's subscription doesn't stop a done event",
           () async {
-        virtual1.stream.listen(null).cancel();
+        unawaited(virtual1.stream.listen(null).cancel());
         await pumpEventQueue();
 
-        virtual2.sink.close();
+        unawaited(virtual2.sink.close());
         await pumpEventQueue();
 
         virtual1.sink.add(1);
         virtual1.sink.add(2);
         virtual1.sink.add(3);
-        virtual1.sink.close();
+        unawaited(virtual1.sink.close());
 
         // The sink should be ignoring events because the stream closed.
         virtual2.stream.listen(expectAsync1((_) {}, count: 0));

--- a/test/stream_channel_completer_test.dart
+++ b/test/stream_channel_completer_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -62,14 +63,14 @@ void main() {
       streamController.add(1);
       streamController.add(2);
       streamController.add(3);
-      streamController.close();
+      unawaited(streamController.close());
     });
 
     test("forwards events through the sink", () async {
       completer.channel.sink.add(1);
       completer.channel.sink.add(2);
       completer.channel.sink.add(3);
-      completer.channel.sink.close();
+      unawaited(completer.channel.sink.close());
       await pumpEventQueue();
 
       completer.setChannel(innerChannel);

--- a/test/stream_channel_test.dart
+++ b/test/stream_channel_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:async/async.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -46,11 +47,11 @@ void main() {
         .transform(StreamChannelTransformer.fromCodec(utf8));
 
     streamController.add([102, 111, 111, 98, 97, 114]);
-    streamController.close();
+    unawaited(streamController.close());
     expect(await transformed.stream.toList(), equals(["foobar"]));
 
     transformed.sink.add("fblthp");
-    transformed.sink.close();
+    unawaited(transformed.sink.close());
     expect(
         sinkController.stream.toList(),
         completion(equals([
@@ -65,12 +66,12 @@ void main() {
     streamController.add("hello world");
     streamController.add(" what\nis");
     streamController.add("\nup");
-    streamController.close();
+    unawaited(streamController.close());
     expect(await transformed.stream.toList(),
         equals(["hello world what", "is", "up"]));
 
     transformed.sink.add("fbl\nthp");
-    transformed.sink.close();
+    unawaited(transformed.sink.close());
     expect(sinkController.stream.toList(), completion(equals(["fbl\nthp"])));
   });
 
@@ -79,13 +80,13 @@ void main() {
         StreamSinkTransformer.fromStreamTransformer(const LineSplitter()));
 
     streamController.add("fbl\nthp");
-    streamController.close();
+    unawaited(streamController.close());
     expect(await transformed.stream.toList(), equals(["fbl\nthp"]));
 
     transformed.sink.add("hello world");
     transformed.sink.add(" what\nis");
     transformed.sink.add("\nup");
-    transformed.sink.close();
+    unawaited(transformed.sink.close());
     expect(sinkController.stream.toList(),
         completion(equals(["hello world what", "is", "up"])));
   });

--- a/test/with_close_guarantee_test.dart
+++ b/test/with_close_guarantee_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -54,7 +55,7 @@ void main() {
   test(
       "closing the event sink before events are emitted causes the stream to "
       "close immediately", () async {
-    channel.sink.close();
+    unawaited(channel.sink.close());
     channel.stream.listen(expectAsync1((_) {}, count: 0),
         onError: expectAsync2((_, __) {}, count: 0),
         onDone: expectAsync0(() {}));
@@ -62,7 +63,7 @@ void main() {
     controller.local.sink.add(1);
     controller.local.sink.add(2);
     controller.local.sink.add(3);
-    controller.local.sink.close();
+    unawaited(controller.local.sink.close());
 
     await pumpEventQueue();
   });

--- a/test/with_guarantees_test.dart
+++ b/test/with_guarantees_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
@@ -32,7 +33,7 @@ void main() {
       await pumpEventQueue();
 
       expect(channel.stream.toList(), completion(equals([1, 2, 3])));
-      streamController.close();
+      unawaited(streamController.close());
     });
 
     test("only allows a single subscription", () {
@@ -58,14 +59,14 @@ void main() {
   });
 
   test("after the stream closes, the sink ignores events", () async {
-    streamController.close();
+    unawaited(streamController.close());
 
     // Wait for the done event to be delivered.
     await channel.stream.toList();
     channel.sink.add(1);
     channel.sink.add(2);
     channel.sink.add(3);
-    channel.sink.close();
+    unawaited(channel.sink.close());
 
     // None of our channel.sink additions should make it to the other endpoint.
     sinkController.stream.listen(expectAsync1((_) {}, count: 0),
@@ -75,28 +76,28 @@ void main() {
 
   test("canceling the stream's subscription has no effect on the sink",
       () async {
-    channel.stream.listen(null).cancel();
+    unawaited(channel.stream.listen(null).cancel());
     await pumpEventQueue();
 
     channel.sink.add(1);
     channel.sink.add(2);
     channel.sink.add(3);
-    channel.sink.close();
+    unawaited(channel.sink.close());
     expect(sinkController.stream.toList(), completion(equals([1, 2, 3])));
   });
 
   test("canceling the stream's subscription doesn't stop a done event",
       () async {
-    channel.stream.listen(null).cancel();
+    unawaited(channel.stream.listen(null).cancel());
     await pumpEventQueue();
 
-    streamController.close();
+    unawaited(streamController.close());
     await pumpEventQueue();
 
     channel.sink.add(1);
     channel.sink.add(2);
     channel.sink.add(3);
-    channel.sink.close();
+    unawaited(channel.sink.close());
 
     // The sink should be ignoring events because the stream closed.
     sinkController.stream.listen(expectAsync1((_) {}, count: 0),


### PR DESCRIPTION
(Alternatively I could ignore the unawaited_futures lint, in each file or in analysis options)