### PR TITLE
Fix newly enforce package:pedantic lints

### DIFF
--- a/lib/src/close_guarantee_channel.dart
+++ b/lib/src/close_guarantee_channel.dart
@@ -48,8 +48,8 @@ class _CloseGuaranteeStream<T> extends Stream<T> {
   _CloseGuaranteeStream(this._inner, this._channel);
 
   @override
-  StreamSubscription<T> listen(void onData(T event),
-      {Function onError, void onDone(), bool cancelOnError}) {
+  StreamSubscription<T> listen(void Function(T) onData,
+      {Function onError, void Function() onDone, bool cancelOnError}) {
     // If the channel is already disconnected, we shouldn't dispatch anything
     // but a done event.
     if (_channel._disconnected) {

--- a/lib/src/disconnector.dart
+++ b/lib/src/disconnector.dart
@@ -87,9 +87,9 @@ class _DisconnectorSink<T> implements StreamSink<T> {
 
   @override
   void add(T data) {
-    if (_closed) throw StateError("Cannot add event after closing.");
+    if (_closed) throw StateError('Cannot add event after closing.');
     if (_inAddStream) {
-      throw StateError("Cannot add event while adding stream.");
+      throw StateError('Cannot add event while adding stream.');
     }
     if (_isDisconnected) return;
 
@@ -98,9 +98,9 @@ class _DisconnectorSink<T> implements StreamSink<T> {
 
   @override
   void addError(error, [StackTrace stackTrace]) {
-    if (_closed) throw StateError("Cannot add event after closing.");
+    if (_closed) throw StateError('Cannot add event after closing.');
     if (_inAddStream) {
-      throw StateError("Cannot add event while adding stream.");
+      throw StateError('Cannot add event while adding stream.');
     }
     if (_isDisconnected) return;
 
@@ -109,9 +109,9 @@ class _DisconnectorSink<T> implements StreamSink<T> {
 
   @override
   Future<void> addStream(Stream<T> stream) {
-    if (_closed) throw StateError("Cannot add stream after closing.");
+    if (_closed) throw StateError('Cannot add stream after closing.');
     if (_inAddStream) {
-      throw StateError("Cannot add stream while adding stream.");
+      throw StateError('Cannot add stream while adding stream.');
     }
     if (_isDisconnected) return Future.value();
 
@@ -127,7 +127,7 @@ class _DisconnectorSink<T> implements StreamSink<T> {
   @override
   Future<void> close() {
     if (_inAddStream) {
-      throw StateError("Cannot close sink while adding stream.");
+      throw StateError('Cannot close sink while adding stream.');
     }
 
     _closed = true;

--- a/lib/src/guarantee_channel.dart
+++ b/lib/src/guarantee_channel.dart
@@ -115,9 +115,9 @@ class _GuaranteeSink<T> implements StreamSink<T> {
 
   @override
   void add(T data) {
-    if (_closed) throw StateError("Cannot add event after closing.");
+    if (_closed) throw StateError('Cannot add event after closing.');
     if (_inAddStream) {
-      throw StateError("Cannot add event while adding stream.");
+      throw StateError('Cannot add event while adding stream.');
     }
     if (_disconnected) return;
 
@@ -126,9 +126,9 @@ class _GuaranteeSink<T> implements StreamSink<T> {
 
   @override
   void addError(error, [StackTrace stackTrace]) {
-    if (_closed) throw StateError("Cannot add event after closing.");
+    if (_closed) throw StateError('Cannot add event after closing.');
     if (_inAddStream) {
-      throw StateError("Cannot add event while adding stream.");
+      throw StateError('Cannot add event while adding stream.');
     }
     if (_disconnected) return;
 
@@ -158,9 +158,9 @@ class _GuaranteeSink<T> implements StreamSink<T> {
 
   @override
   Future<void> addStream(Stream<T> stream) {
-    if (_closed) throw StateError("Cannot add stream after closing.");
+    if (_closed) throw StateError('Cannot add stream after closing.');
     if (_inAddStream) {
-      throw StateError("Cannot add stream while adding stream.");
+      throw StateError('Cannot add stream while adding stream.');
     }
     if (_disconnected) return Future.value();
 
@@ -176,7 +176,7 @@ class _GuaranteeSink<T> implements StreamSink<T> {
   @override
   Future<void> close() {
     if (_inAddStream) {
-      throw StateError("Cannot close sink while adding stream.");
+      throw StateError('Cannot close sink while adding stream.');
     }
 
     if (_closed) return done;

--- a/lib/src/multi_channel.dart
+++ b/lib/src/multi_channel.dart
@@ -104,11 +104,11 @@ class _MultiChannel<T> extends StreamChannelMixin<T>
 
   /// Input IDs of controllers in [_controllers] that we've received messages
   /// for but that have not yet had a local [virtualChannel] created.
-  final _pendingIds = Set<int>();
+  final _pendingIds = <int>{};
 
   /// Input IDs of virtual channels that used to exist but have since been
   /// closed.
-  final _closedIds = Set<int>();
+  final _closedIds = <int>{};
 
   /// The next id to use for a local virtual channel.
   ///
@@ -201,7 +201,7 @@ class _MultiChannel<T> extends StreamChannelMixin<T>
       controller = _controllers[inputId];
     } else if (_controllers.containsKey(inputId) ||
         _closedIds.contains(inputId)) {
-      throw ArgumentError("A virtual channel with id $id already exists.");
+      throw ArgumentError('A virtual channel with id $id already exists.');
     } else {
       controller = StreamChannelController(sync: true);
       _controllers[inputId] = controller;

--- a/lib/src/stream_channel_completer.dart
+++ b/lib/src/stream_channel_completer.dart
@@ -52,7 +52,7 @@ class StreamChannelCompleter<T> {
   /// Either [setChannel] or [setError] may be called at most once. Trying to
   /// call either of them again will fail.
   void setChannel(StreamChannel<T> channel) {
-    if (_set) throw StateError("The channel has already been set.");
+    if (_set) throw StateError('The channel has already been set.');
     _set = true;
 
     _streamCompleter.setSourceStream(channel.stream);
@@ -67,7 +67,7 @@ class StreamChannelCompleter<T> {
   /// Either [setChannel] or [setError] may be called at most once. Trying to
   /// call either of them again will fail.
   void setError(error, [StackTrace stackTrace]) {
-    if (_set) throw StateError("The channel has already been set.");
+    if (_set) throw StateError('The channel has already been set.');
     _set = true;
 
     _streamCompleter.setError(error, stackTrace);

--- a/lib/stream_channel.dart
+++ b/lib/stream_channel.dart
@@ -117,11 +117,11 @@ abstract class StreamChannel<T> {
 
   /// Returns a copy of this with [stream] replaced by [change]'s return
   /// value.
-  StreamChannel<T> changeStream(Stream<T> change(Stream<T> stream));
+  StreamChannel<T> changeStream(Stream<T> Function(Stream<T>) change);
 
   /// Returns a copy of this with [sink] replaced by [change]'s return
   /// value.
-  StreamChannel<T> changeSink(StreamSink<T> change(StreamSink<T> sink));
+  StreamChannel<T> changeSink(StreamSink<T> Function(StreamSink<T>) change);
 
   /// Returns a copy of this with the generic type coerced to [S].
   ///
@@ -167,11 +167,11 @@ abstract class StreamChannelMixin<T> implements StreamChannel<T> {
       changeSink(transformer.bind);
 
   @override
-  StreamChannel<T> changeStream(Stream<T> change(Stream<T> stream)) =>
+  StreamChannel<T> changeStream(Stream<T> Function(Stream<T>) change) =>
       StreamChannel.withCloseGuarantee(change(stream), sink);
 
   @override
-  StreamChannel<T> changeSink(StreamSink<T> change(StreamSink<T> sink)) =>
+  StreamChannel<T> changeSink(StreamSink<T> Function(StreamSink<T>) change) =>
       StreamChannel.withCloseGuarantee(stream, change(sink));
 
   @override

--- a/test/disconnector_test.dart
+++ b/test/disconnector_test.dart
@@ -23,8 +23,8 @@ void main() {
         .transform(disconnector);
   });
 
-  group("before disconnection", () {
-    test("forwards events from the sink as normal", () {
+  group('before disconnection', () {
+    test('forwards events from the sink as normal', () {
       channel.sink.add(1);
       channel.sink.add(2);
       channel.sink.add(3);
@@ -33,7 +33,7 @@ void main() {
       expect(sinkController.stream.toList(), completion(equals([1, 2, 3])));
     });
 
-    test("forwards events to the stream as normal", () {
+    test('forwards events to the stream as normal', () {
       streamController.add(1);
       streamController.add(2);
       streamController.add(3);
@@ -47,7 +47,7 @@ void main() {
 
       expect(channel.sink.close(), completes);
       expect(() => channel.sink.add(1), throwsStateError);
-      expect(() => channel.sink.addError("oh no"), throwsStateError);
+      expect(() => channel.sink.addError('oh no'), throwsStateError);
       expect(() => channel.sink.addStream(Stream.fromIterable([])),
           throwsStateError);
     });
@@ -57,7 +57,7 @@ void main() {
       channel.sink.addStream(controller.stream);
 
       expect(() => channel.sink.add(1), throwsStateError);
-      expect(() => channel.sink.addError("oh no"), throwsStateError);
+      expect(() => channel.sink.addError('oh no'), throwsStateError);
       expect(() => channel.sink.addStream(Stream.fromIterable([])),
           throwsStateError);
       expect(() => channel.sink.close(), throwsStateError);
@@ -66,7 +66,7 @@ void main() {
     });
   });
 
-  test("cancels addStream when disconnected", () async {
+  test('cancels addStream when disconnected', () async {
     var canceled = false;
     var controller = StreamController(onCancel: () {
       canceled = true;
@@ -78,7 +78,7 @@ void main() {
     expect(canceled, isTrue);
   });
 
-  test("disconnect() returns the close future from the inner sink", () async {
+  test('disconnect() returns the close future from the inner sink', () async {
     var streamController = StreamController();
     var sinkController = StreamController();
     var disconnector = Disconnector();
@@ -104,12 +104,12 @@ void main() {
     expect(disconnectFutureFired, isTrue);
   });
 
-  group("after disconnection", () {
+  group('after disconnection', () {
     setUp(() {
       disconnector.disconnect();
     });
 
-    test("closes the inner sink and ignores events to the outer sink", () {
+    test('closes the inner sink and ignores events to the outer sink', () {
       channel.sink.add(1);
       channel.sink.add(2);
       channel.sink.add(3);
@@ -118,21 +118,21 @@ void main() {
       expect(sinkController.stream.toList(), completion(isEmpty));
     });
 
-    test("closes the stream", () {
+    test('closes the stream', () {
       expect(channel.stream.toList(), completion(isEmpty));
     });
 
-    test("completes done", () {
+    test('completes done', () {
       sinkController.stream.listen(null); // Work around sdk#19095.
       expect(channel.sink.done, completes);
     });
 
-    test("still emits state errors after explicit close", () {
+    test('still emits state errors after explicit close', () {
       sinkController.stream.listen(null); // Work around sdk#19095.
       expect(channel.sink.close(), completes);
 
       expect(() => channel.sink.add(1), throwsStateError);
-      expect(() => channel.sink.addError("oh no"), throwsStateError);
+      expect(() => channel.sink.addError('oh no'), throwsStateError);
     });
   });
 }

--- a/test/isolate_channel_test.dart
+++ b/test/isolate_channel_test.dart
@@ -28,7 +28,7 @@ void main() {
     channel.sink.close();
   });
 
-  test("the channel can send messages", () {
+  test('the channel can send messages', () {
     channel.sink.add(1);
     channel.sink.add(2);
     channel.sink.add(3);
@@ -36,7 +36,7 @@ void main() {
     expect(receivePort.take(3).toList(), completion(equals([1, 2, 3])));
   });
 
-  test("the channel can receive messages", () {
+  test('the channel can receive messages', () {
     sendPort.send(1);
     sendPort.send(2);
     sendPort.send(3);
@@ -47,7 +47,7 @@ void main() {
   test("events can't be added to an explicitly-closed sink", () {
     expect(channel.sink.close(), completes);
     expect(() => channel.sink.add(1), throwsStateError);
-    expect(() => channel.sink.addError("oh no"), throwsStateError);
+    expect(() => channel.sink.addError('oh no'), throwsStateError);
     expect(() => channel.sink.addStream(Stream.fromIterable([])),
         throwsStateError);
   });
@@ -57,7 +57,7 @@ void main() {
     channel.sink.addStream(controller.stream);
 
     expect(() => channel.sink.add(1), throwsStateError);
-    expect(() => channel.sink.addError("oh no"), throwsStateError);
+    expect(() => channel.sink.addError('oh no'), throwsStateError);
     expect(() => channel.sink.addStream(Stream.fromIterable([])),
         throwsStateError);
     expect(() => channel.sink.close(), throwsStateError);
@@ -65,10 +65,10 @@ void main() {
     controller.close();
   });
 
-  group("stream channel rules", () {
+  group('stream channel rules', () {
     test(
-        "closing the sink causes the stream to close before it emits any more "
-        "events", () {
+        'closing the sink causes the stream to close before it emits any more '
+        'events', () {
       sendPort.send(1);
       sendPort.send(2);
       sendPort.send(3);
@@ -92,10 +92,10 @@ void main() {
       expect(receivePort.take(3).toList(), completion(equals([1, 2, 3])));
     });
 
-    test("the sink closes as soon as an error is added", () async {
-      channel.sink.addError("oh no");
+    test('the sink closes as soon as an error is added', () async {
+      channel.sink.addError('oh no');
       channel.sink.add(1);
-      expect(channel.sink.done, throwsA("oh no"));
+      expect(channel.sink.done, throwsA('oh no'));
 
       // Since the sink is closed, the stream should also be closed.
       expect(channel.stream.isEmpty, completion(isTrue));
@@ -106,7 +106,7 @@ void main() {
       await pumpEventQueue();
     });
 
-    test("the sink closes as soon as an error is added via addStream",
+    test('the sink closes as soon as an error is added via addStream',
         () async {
       var canceled = false;
       var controller = StreamController(onCancel: () {
@@ -116,8 +116,8 @@ void main() {
       // This future shouldn't get the error, because it's sent to [Sink.done].
       expect(channel.sink.addStream(controller.stream), completes);
 
-      controller.addError("oh no");
-      expect(channel.sink.done, throwsA("oh no"));
+      controller.addError('oh no');
+      expect(channel.sink.done, throwsA('oh no'));
       await pumpEventQueue();
       expect(canceled, isTrue);
 
@@ -127,7 +127,7 @@ void main() {
     });
   });
 
-  group("connect constructors", () {
+  group('connect constructors', () {
     ReceivePort connectPort;
     setUp(() {
       connectPort = ReceivePort();
@@ -137,7 +137,7 @@ void main() {
       connectPort.close();
     });
 
-    test("create a connected pair of channels", () {
+    test('create a connected pair of channels', () {
       var channel1 = IsolateChannel<int>.connectReceive(connectPort);
       var channel2 = IsolateChannel<int>.connectSend(connectPort.sendPort);
 
@@ -152,10 +152,10 @@ void main() {
       expect(channel1.stream.take(3).toList(), completion(equals([4, 5, 6])));
     });
 
-    test("the receiving channel produces an error if it gets the wrong message",
+    test('the receiving channel produces an error if it gets the wrong message',
         () {
       var connectedChannel = IsolateChannel.connectReceive(connectPort);
-      connectPort.sendPort.send("wrong value");
+      connectPort.sendPort.send('wrong value');
 
       expect(connectedChannel.stream.toList(), throwsStateError);
       expect(connectedChannel.sink.done, completes);

--- a/test/json_document_transformer_test.dart
+++ b/test/json_document_transformer_test.dart
@@ -19,26 +19,26 @@ void main() {
         StreamChannel<String>(streamController.stream, sinkController.sink);
   });
 
-  test("decodes JSON emitted by the channel", () {
+  test('decodes JSON emitted by the channel', () {
     var transformed = channel.transform(jsonDocument);
     streamController.add('{"foo": "bar"}');
-    expect(transformed.stream.first, completion(equals({"foo": "bar"})));
+    expect(transformed.stream.first, completion(equals({'foo': 'bar'})));
   });
 
-  test("encodes objects added to the channel", () {
+  test('encodes objects added to the channel', () {
     var transformed = channel.transform(jsonDocument);
-    transformed.sink.add({"foo": "bar"});
+    transformed.sink.add({'foo': 'bar'});
     expect(sinkController.stream.first,
-        completion(equals(jsonEncode({"foo": "bar"}))));
+        completion(equals(jsonEncode({'foo': 'bar'}))));
   });
 
-  test("emits a stream error when incoming JSON is malformed", () {
+  test('emits a stream error when incoming JSON is malformed', () {
     var transformed = channel.transform(jsonDocument);
-    streamController.add("{invalid");
+    streamController.add('{invalid');
     expect(transformed.stream.first, throwsFormatException);
   });
 
-  test("synchronously throws if an unencodable object is added", () {
+  test('synchronously throws if an unencodable object is added', () {
     var transformed = channel.transform(jsonDocument);
     expect(() => transformed.sink.add(Object()),
         throwsA(TypeMatcher<JsonUnsupportedObjectError>()));

--- a/test/multi_channel_test.dart
+++ b/test/multi_channel_test.dart
@@ -16,8 +16,8 @@ void main() {
     channel2 = MultiChannel<int>(controller.foreign);
   });
 
-  group("the default virtual channel", () {
-    test("begins connected", () {
+  group('the default virtual channel', () {
+    test('begins connected', () {
       var first = true;
       channel2.stream.listen(expectAsync1((message) {
         if (first) {
@@ -32,14 +32,14 @@ void main() {
       channel1.sink.add(2);
     });
 
-    test("closes the remote virtual channel when it closes", () {
+    test('closes the remote virtual channel when it closes', () {
       expect(channel2.stream.toList(), completion(isEmpty));
       expect(channel2.sink.done, completes);
 
       channel1.sink.close();
     });
 
-    test("closes the local virtual channel when it closes", () {
+    test('closes the local virtual channel when it closes', () {
       expect(channel1.stream.toList(), completion(isEmpty));
       expect(channel1.sink.done, completes);
 
@@ -48,7 +48,7 @@ void main() {
 
     test(
         "doesn't closes the local virtual channel when the stream "
-        "subscription is canceled", () {
+        'subscription is canceled', () {
       channel1.sink.done.then(expectAsync1((_) {}, count: 0));
 
       channel1.stream.listen((_) {}).cancel();
@@ -59,8 +59,8 @@ void main() {
     });
 
     test(
-        "closes the underlying channel when it closes without any other "
-        "virtual channels", () {
+        'closes the underlying channel when it closes without any other '
+        'virtual channels', () {
       expect(controller.local.sink.done, completes);
       expect(controller.foreign.sink.done, completes);
 
@@ -69,7 +69,7 @@ void main() {
 
     test(
         "doesn't close the underlying channel when it closes with other "
-        "virtual channels", () {
+        'virtual channels', () {
       controller.local.sink.done.then(expectAsync1((_) {}, count: 0));
       controller.foreign.sink.done.then(expectAsync1((_) {}, count: 0));
 
@@ -84,7 +84,7 @@ void main() {
     });
   });
 
-  group("a locally-created virtual channel", () {
+  group('a locally-created virtual channel', () {
     VirtualChannel virtual1;
     VirtualChannel virtual2;
     setUp(() {
@@ -92,7 +92,7 @@ void main() {
       virtual2 = channel2.virtualChannel(virtual1.id);
     });
 
-    test("sends messages only to the other virtual channel", () {
+    test('sends messages only to the other virtual channel', () {
       var first = true;
       virtual2.stream.listen(expectAsync1((message) {
         if (first) {
@@ -114,14 +114,14 @@ void main() {
       virtual1.sink.add(2);
     });
 
-    test("closes the remote virtual channel when it closes", () {
+    test('closes the remote virtual channel when it closes', () {
       expect(virtual2.stream.toList(), completion(isEmpty));
       expect(virtual2.sink.done, completes);
 
       virtual1.sink.close();
     });
 
-    test("closes the local virtual channel when it closes", () {
+    test('closes the local virtual channel when it closes', () {
       expect(virtual1.stream.toList(), completion(isEmpty));
       expect(virtual1.sink.done, completes);
 
@@ -130,7 +130,7 @@ void main() {
 
     test(
         "doesn't closes the local virtual channel when the stream "
-        "subscription is canceled", () {
+        'subscription is canceled', () {
       virtual1.sink.done.then(expectAsync1((_) {}, count: 0));
       virtual1.stream.listen((_) {}).cancel();
 
@@ -140,8 +140,8 @@ void main() {
     });
 
     test(
-        "closes the underlying channel when it closes without any other "
-        "virtual channels", () async {
+        'closes the underlying channel when it closes without any other '
+        'virtual channels', () async {
       // First close the default channel so we can test the new channel as the
       // last living virtual channel.
       unawaited(channel1.sink.close());
@@ -155,7 +155,7 @@ void main() {
 
     test(
         "doesn't close the underlying channel when it closes with other "
-        "virtual channels", () {
+        'virtual channels', () {
       controller.local.sink.done.then(expectAsync1((_) {}, count: 0));
       controller.foreign.sink.done.then(expectAsync1((_) {}, count: 0));
 
@@ -184,7 +184,7 @@ void main() {
     });
   });
 
-  group("a remotely-created virtual channel", () {
+  group('a remotely-created virtual channel', () {
     VirtualChannel virtual1;
     VirtualChannel virtual2;
     setUp(() {
@@ -192,7 +192,7 @@ void main() {
       virtual2 = channel2.virtualChannel(virtual1.id);
     });
 
-    test("sends messages only to the other virtual channel", () {
+    test('sends messages only to the other virtual channel', () {
       var first = true;
       virtual1.stream.listen(expectAsync1((message) {
         if (first) {
@@ -214,14 +214,14 @@ void main() {
       virtual2.sink.add(2);
     });
 
-    test("closes the remote virtual channel when it closes", () {
+    test('closes the remote virtual channel when it closes', () {
       expect(virtual1.stream.toList(), completion(isEmpty));
       expect(virtual1.sink.done, completes);
 
       virtual2.sink.close();
     });
 
-    test("closes the local virtual channel when it closes", () {
+    test('closes the local virtual channel when it closes', () {
       expect(virtual2.stream.toList(), completion(isEmpty));
       expect(virtual2.sink.done, completes);
 
@@ -230,7 +230,7 @@ void main() {
 
     test(
         "doesn't closes the local virtual channel when the stream "
-        "subscription is canceled", () {
+        'subscription is canceled', () {
       virtual2.sink.done.then(expectAsync1((_) {}, count: 0));
       virtual2.stream.listen((_) {}).cancel();
 
@@ -240,8 +240,8 @@ void main() {
     });
 
     test(
-        "closes the underlying channel when it closes without any other "
-        "virtual channels", () async {
+        'closes the underlying channel when it closes without any other '
+        'virtual channels', () async {
       // First close the default channel so we can test the new channel as the
       // last living virtual channel.
       unawaited(channel2.sink.close());
@@ -255,7 +255,7 @@ void main() {
 
     test(
         "doesn't close the underlying channel when it closes with other "
-        "virtual channels", () {
+        'virtual channels', () {
       controller.local.sink.done.then(expectAsync1((_) {}, count: 0));
       controller.foreign.sink.done.then(expectAsync1((_) {}, count: 0));
 
@@ -270,7 +270,7 @@ void main() {
       expect(() => channel2.virtualChannel(virtual1.id), throwsArgumentError);
     });
 
-    test("dispatches events received before the virtual channel is created",
+    test('dispatches events received before the virtual channel is created',
         () async {
       virtual1 = channel1.virtualChannel();
 
@@ -284,8 +284,8 @@ void main() {
     });
 
     test(
-        "dispatches close events received before the virtual channel is "
-        "created", () async {
+        'dispatches close events received before the virtual channel is '
+        'created', () async {
       virtual1 = channel1.virtualChannel();
 
       unawaited(virtual1.sink.close());
@@ -296,7 +296,7 @@ void main() {
     });
   });
 
-  group("when the underlying stream", () {
+  group('when the underlying stream', () {
     VirtualChannel virtual1;
     VirtualChannel virtual2;
     setUp(() {
@@ -304,7 +304,7 @@ void main() {
       virtual2 = channel2.virtualChannel(virtual1.id);
     });
 
-    test("closes, all virtual channels close", () {
+    test('closes, all virtual channels close', () {
       expect(channel1.stream.toList(), completion(isEmpty));
       expect(channel1.sink.done, completes);
       expect(channel2.stream.toList(), completion(isEmpty));
@@ -317,7 +317,7 @@ void main() {
       controller.local.sink.close();
     });
 
-    test("closes, more virtual channels are created closed", () async {
+    test('closes, more virtual channels are created closed', () async {
       unawaited(channel2.sink.close());
       unawaited(virtual2.sink.close());
 
@@ -334,21 +334,21 @@ void main() {
       expect(virtual.sink.done, completes);
     });
 
-    test("emits an error, the error is sent only to the default channel", () {
+    test('emits an error, the error is sent only to the default channel', () {
       channel1.stream.listen(expectAsync1((_) {}, count: 0),
-          onError: expectAsync1((error) => expect(error, equals("oh no"))));
+          onError: expectAsync1((error) => expect(error, equals('oh no'))));
       virtual1.stream.listen(expectAsync1((_) {}, count: 0),
           onError: expectAsync1((_) {}, count: 0));
 
-      controller.foreign.sink.addError("oh no");
+      controller.foreign.sink.addError('oh no');
     });
   });
 
-  group("stream channel rules", () {
-    group("for the main stream:", () {
+  group('stream channel rules', () {
+    group('for the main stream:', () {
       test(
-          "closing the sink causes the stream to close before it emits any more "
-          "events", () {
+          'closing the sink causes the stream to close before it emits any more '
+          'events', () {
         channel1.sink.add(1);
         channel1.sink.add(2);
         channel1.sink.add(3);
@@ -359,7 +359,7 @@ void main() {
         }, count: 1));
       });
 
-      test("after the stream closes, the sink ignores events", () async {
+      test('after the stream closes, the sink ignores events', () async {
         unawaited(channel1.sink.close());
 
         // Wait for the done event to be delivered.
@@ -405,7 +405,7 @@ void main() {
       });
     });
 
-    group("for a virtual channel:", () {
+    group('for a virtual channel:', () {
       VirtualChannel virtual1;
       VirtualChannel virtual2;
       setUp(() {
@@ -414,8 +414,8 @@ void main() {
       });
 
       test(
-          "closing the sink causes the stream to close before it emits any more "
-          "events", () {
+          'closing the sink causes the stream to close before it emits any more '
+          'events', () {
         virtual1.sink.add(1);
         virtual1.sink.add(2);
         virtual1.sink.add(3);
@@ -426,7 +426,7 @@ void main() {
         }, count: 1));
       });
 
-      test("after the stream closes, the sink ignores events", () async {
+      test('after the stream closes, the sink ignores events', () async {
         unawaited(virtual1.sink.close());
 
         // Wait for the done event to be delivered.

--- a/test/stream_channel_completer_test.dart
+++ b/test/stream_channel_completer_test.dart
@@ -20,8 +20,8 @@ void main() {
     innerChannel = StreamChannel(streamController.stream, sinkController.sink);
   });
 
-  group("when a channel is set before accessing", () {
-    test("forwards events through the stream", () {
+  group('when a channel is set before accessing', () {
+    test('forwards events through the stream', () {
       completer.setChannel(innerChannel);
       expect(completer.channel.stream.toList(), completion(equals([1, 2, 3])));
 
@@ -31,7 +31,7 @@ void main() {
       streamController.close();
     });
 
-    test("forwards events through the sink", () {
+    test('forwards events through the sink', () {
       completer.setChannel(innerChannel);
       expect(sinkController.stream.toList(), completion(equals([1, 2, 3])));
 
@@ -41,21 +41,21 @@ void main() {
       completer.channel.sink.close();
     });
 
-    test("forwards an error through the stream", () {
-      completer.setError("oh no");
-      expect(completer.channel.stream.first, throwsA("oh no"));
+    test('forwards an error through the stream', () {
+      completer.setError('oh no');
+      expect(completer.channel.stream.first, throwsA('oh no'));
     });
 
-    test("drops sink events", () {
-      completer.setError("oh no");
+    test('drops sink events', () {
+      completer.setError('oh no');
       expect(completer.channel.sink.done, completes);
       completer.channel.sink.add(1);
-      completer.channel.sink.addError("oh no");
+      completer.channel.sink.addError('oh no');
     });
   });
 
-  group("when a channel is set after accessing", () {
-    test("forwards events through the stream", () async {
+  group('when a channel is set after accessing', () {
+    test('forwards events through the stream', () async {
       expect(completer.channel.stream.toList(), completion(equals([1, 2, 3])));
       await pumpEventQueue();
 
@@ -66,7 +66,7 @@ void main() {
       unawaited(streamController.close());
     });
 
-    test("forwards events through the sink", () async {
+    test('forwards events through the sink', () async {
       completer.channel.sink.add(1);
       completer.channel.sink.add(2);
       completer.channel.sink.add(3);
@@ -77,25 +77,25 @@ void main() {
       expect(sinkController.stream.toList(), completion(equals([1, 2, 3])));
     });
 
-    test("forwards an error through the stream", () async {
-      expect(completer.channel.stream.first, throwsA("oh no"));
+    test('forwards an error through the stream', () async {
+      expect(completer.channel.stream.first, throwsA('oh no'));
       await pumpEventQueue();
 
-      completer.setError("oh no");
+      completer.setError('oh no');
     });
 
-    test("drops sink events", () async {
+    test('drops sink events', () async {
       expect(completer.channel.sink.done, completes);
       completer.channel.sink.add(1);
-      completer.channel.sink.addError("oh no");
+      completer.channel.sink.addError('oh no');
       await pumpEventQueue();
 
-      completer.setError("oh no");
+      completer.setError('oh no');
     });
   });
 
-  group("forFuture", () {
-    test("forwards a StreamChannel", () {
+  group('forFuture', () {
+    test('forwards a StreamChannel', () {
       var channel =
           StreamChannelCompleter.fromFuture(Future.value(innerChannel));
       channel.sink.add(1);
@@ -107,9 +107,9 @@ void main() {
       expect(channel.stream.toList(), completion(equals([2])));
     });
 
-    test("forwards an error", () {
-      var channel = StreamChannelCompleter.fromFuture(Future.error("oh no"));
-      expect(channel.stream.toList(), throwsA("oh no"));
+    test('forwards an error', () {
+      var channel = StreamChannelCompleter.fromFuture(Future.error('oh no'));
+      expect(channel.stream.toList(), throwsA('oh no'));
     });
   });
 

--- a/test/stream_channel_controller_test.dart
+++ b/test/stream_channel_controller_test.dart
@@ -6,13 +6,13 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group("asynchronously", () {
+  group('asynchronously', () {
     StreamChannelController controller;
     setUp(() {
       controller = StreamChannelController();
     });
 
-    test("forwards events from the local sink to the foreign stream", () {
+    test('forwards events from the local sink to the foreign stream', () {
       controller.local.sink
         ..add(1)
         ..add(2)
@@ -21,7 +21,7 @@ void main() {
       expect(controller.foreign.stream.toList(), completion(equals([1, 2, 3])));
     });
 
-    test("forwards events from the foreign sink to the local stream", () {
+    test('forwards events from the foreign sink to the local stream', () {
       controller.foreign.sink
         ..add(1)
         ..add(2)
@@ -31,27 +31,27 @@ void main() {
     });
 
     test(
-        "with allowForeignErrors: false, shuts down the connection if an "
-        "error is added to the foreign channel", () {
+        'with allowForeignErrors: false, shuts down the connection if an '
+        'error is added to the foreign channel', () {
       controller = StreamChannelController(allowForeignErrors: false);
 
-      controller.foreign.sink.addError("oh no");
-      expect(controller.foreign.sink.done, throwsA("oh no"));
+      controller.foreign.sink.addError('oh no');
+      expect(controller.foreign.sink.done, throwsA('oh no'));
       expect(controller.foreign.stream.toList(), completion(isEmpty));
       expect(controller.local.sink.done, completes);
       expect(controller.local.stream.toList(), completion(isEmpty));
     });
   });
 
-  group("synchronously", () {
+  group('synchronously', () {
     StreamChannelController controller;
     setUp(() {
       controller = StreamChannelController(sync: true);
     });
 
     test(
-        "synchronously forwards events from the local sink to the foreign "
-        "stream", () {
+        'synchronously forwards events from the local sink to the foreign '
+        'stream', () {
       var receivedEvent = false;
       var receivedError = false;
       var receivedDone = false;
@@ -59,7 +59,7 @@ void main() {
         expect(event, equals(1));
         receivedEvent = true;
       }), onError: expectAsync1((error) {
-        expect(error, equals("oh no"));
+        expect(error, equals('oh no'));
         receivedError = true;
       }), onDone: expectAsync0(() {
         receivedDone = true;
@@ -68,7 +68,7 @@ void main() {
       controller.local.sink.add(1);
       expect(receivedEvent, isTrue);
 
-      controller.local.sink.addError("oh no");
+      controller.local.sink.addError('oh no');
       expect(receivedError, isTrue);
 
       controller.local.sink.close();
@@ -76,8 +76,8 @@ void main() {
     });
 
     test(
-        "synchronously forwards events from the foreign sink to the local "
-        "stream", () {
+        'synchronously forwards events from the foreign sink to the local '
+        'stream', () {
       var receivedEvent = false;
       var receivedError = false;
       var receivedDone = false;
@@ -85,7 +85,7 @@ void main() {
         expect(event, equals(1));
         receivedEvent = true;
       }), onError: expectAsync1((error) {
-        expect(error, equals("oh no"));
+        expect(error, equals('oh no'));
         receivedError = true;
       }), onDone: expectAsync0(() {
         receivedDone = true;
@@ -94,7 +94,7 @@ void main() {
       controller.foreign.sink.add(1);
       expect(receivedEvent, isTrue);
 
-      controller.foreign.sink.addError("oh no");
+      controller.foreign.sink.addError('oh no');
       expect(receivedError, isTrue);
 
       controller.foreign.sink.close();

--- a/test/stream_channel_test.dart
+++ b/test/stream_channel_test.dart
@@ -41,16 +41,16 @@ void main() {
     expect(sinkController.stream.toList(), completion(equals([4, 5, 6])));
   });
 
-  test("transform() transforms the channel", () async {
+  test('transform() transforms the channel', () async {
     var transformed = channel
         .cast<List<int>>()
         .transform(StreamChannelTransformer.fromCodec(utf8));
 
     streamController.add([102, 111, 111, 98, 97, 114]);
     unawaited(streamController.close());
-    expect(await transformed.stream.toList(), equals(["foobar"]));
+    expect(await transformed.stream.toList(), equals(['foobar']));
 
-    transformed.sink.add("fblthp");
+    transformed.sink.add('fblthp');
     unawaited(transformed.sink.close());
     expect(
         sinkController.stream.toList(),
@@ -59,39 +59,39 @@ void main() {
         ])));
   });
 
-  test("transformStream() transforms only the stream", () async {
+  test('transformStream() transforms only the stream', () async {
     var transformed =
         channel.cast<String>().transformStream(const LineSplitter());
 
-    streamController.add("hello world");
-    streamController.add(" what\nis");
-    streamController.add("\nup");
+    streamController.add('hello world');
+    streamController.add(' what\nis');
+    streamController.add('\nup');
     unawaited(streamController.close());
     expect(await transformed.stream.toList(),
-        equals(["hello world what", "is", "up"]));
+        equals(['hello world what', 'is', 'up']));
 
-    transformed.sink.add("fbl\nthp");
+    transformed.sink.add('fbl\nthp');
     unawaited(transformed.sink.close());
-    expect(sinkController.stream.toList(), completion(equals(["fbl\nthp"])));
+    expect(sinkController.stream.toList(), completion(equals(['fbl\nthp'])));
   });
 
-  test("transformSink() transforms only the sink", () async {
+  test('transformSink() transforms only the sink', () async {
     var transformed = channel.cast<String>().transformSink(
         StreamSinkTransformer.fromStreamTransformer(const LineSplitter()));
 
-    streamController.add("fbl\nthp");
+    streamController.add('fbl\nthp');
     unawaited(streamController.close());
-    expect(await transformed.stream.toList(), equals(["fbl\nthp"]));
+    expect(await transformed.stream.toList(), equals(['fbl\nthp']));
 
-    transformed.sink.add("hello world");
-    transformed.sink.add(" what\nis");
-    transformed.sink.add("\nup");
+    transformed.sink.add('hello world');
+    transformed.sink.add(' what\nis');
+    transformed.sink.add('\nup');
     unawaited(transformed.sink.close());
     expect(sinkController.stream.toList(),
-        completion(equals(["hello world what", "is", "up"])));
+        completion(equals(['hello world what', 'is', 'up'])));
   });
 
-  test("changeStream() changes the stream", () {
+  test('changeStream() changes the stream', () {
     var newController = StreamController();
     var changed = channel.changeStream((stream) {
       expect(stream, equals(channel.stream));
@@ -107,7 +107,7 @@ void main() {
     expect(changed.stream.toList(), completion(equals([10])));
   });
 
-  test("changeSink() changes the sink", () {
+  test('changeSink() changes the sink', () {
     var newController = StreamController();
     var changed = channel.changeSink((sink) {
       expect(sink, equals(channel.sink));

--- a/test/with_close_guarantee_test.dart
+++ b/test/with_close_guarantee_test.dart
@@ -35,8 +35,8 @@ void main() {
   });
 
   test(
-      "closing the event sink causes the stream to close before it emits any "
-      "more events", () async {
+      'closing the event sink causes the stream to close before it emits any '
+      'more events', () async {
     controller.local.sink.add(1);
     controller.local.sink.add(2);
     controller.local.sink.add(3);
@@ -53,8 +53,8 @@ void main() {
   });
 
   test(
-      "closing the event sink before events are emitted causes the stream to "
-      "close immediately", () async {
+      'closing the event sink before events are emitted causes the stream to '
+      'close immediately', () async {
     unawaited(channel.sink.close());
     channel.stream.listen(expectAsync1((_) {}, count: 0),
         onError: expectAsync2((_, __) {}, count: 0),

--- a/test/with_guarantees_test.dart
+++ b/test/with_guarantees_test.dart
@@ -19,14 +19,14 @@ void main() {
         streamController.stream, sinkController.sink);
   });
 
-  group("with a broadcast stream", () {
+  group('with a broadcast stream', () {
     setUp(() {
       streamController = StreamController.broadcast();
       channel = StreamChannel.withGuarantees(
           streamController.stream, sinkController.sink);
     });
 
-    test("buffers events", () async {
+    test('buffers events', () async {
       streamController.add(1);
       streamController.add(2);
       streamController.add(3);
@@ -36,15 +36,15 @@ void main() {
       unawaited(streamController.close());
     });
 
-    test("only allows a single subscription", () {
+    test('only allows a single subscription', () {
       channel.stream.listen(null);
       expect(() => channel.stream.listen(null), throwsStateError);
     });
   });
 
   test(
-      "closing the event sink causes the stream to close before it emits any "
-      "more events", () {
+      'closing the event sink causes the stream to close before it emits any '
+      'more events', () {
     streamController.add(1);
     streamController.add(2);
     streamController.add(3);
@@ -58,7 +58,7 @@ void main() {
         completes);
   });
 
-  test("after the stream closes, the sink ignores events", () async {
+  test('after the stream closes, the sink ignores events', () async {
     unawaited(streamController.close());
 
     // Wait for the done event to be delivered.
@@ -105,12 +105,12 @@ void main() {
     await pumpEventQueue();
   });
 
-  test("forwards errors to the other endpoint", () {
-    channel.sink.addError("error");
-    expect(sinkController.stream.first, throwsA("error"));
+  test('forwards errors to the other endpoint', () {
+    channel.sink.addError('error');
+    expect(sinkController.stream.first, throwsA('error'));
   });
 
-  test("Sink.done completes once the stream is done", () {
+  test('Sink.done completes once the stream is done', () {
     channel.stream.listen(null);
     expect(channel.sink.done, completes);
     streamController.close();
@@ -121,7 +121,7 @@ void main() {
 
     expect(channel.sink.close(), completes);
     expect(() => channel.sink.add(1), throwsStateError);
-    expect(() => channel.sink.addError("oh no"), throwsStateError);
+    expect(() => channel.sink.addError('oh no'), throwsStateError);
     expect(() => channel.sink.addStream(Stream.fromIterable([])),
         throwsStateError);
   });
@@ -131,7 +131,7 @@ void main() {
     channel.sink.addStream(controller.stream);
 
     expect(() => channel.sink.add(1), throwsStateError);
-    expect(() => channel.sink.addError("oh no"), throwsStateError);
+    expect(() => channel.sink.addError('oh no'), throwsStateError);
     expect(() => channel.sink.addStream(Stream.fromIterable([])),
         throwsStateError);
     expect(() => channel.sink.close(), throwsStateError);
@@ -139,7 +139,7 @@ void main() {
     controller.close();
   });
 
-  group("with allowSinkErrors: false", () {
+  group('with allowSinkErrors: false', () {
     setUp(() {
       streamController = StreamController();
       sinkController = StreamController();
@@ -148,15 +148,15 @@ void main() {
           allowSinkErrors: false);
     });
 
-    test("forwards errors to Sink.done but not the stream", () {
-      channel.sink.addError("oh no");
-      expect(channel.sink.done, throwsA("oh no"));
+    test('forwards errors to Sink.done but not the stream', () {
+      channel.sink.addError('oh no');
+      expect(channel.sink.done, throwsA('oh no'));
       sinkController.stream
           .listen(null, onError: expectAsync1((_) {}, count: 0));
     });
 
-    test("adding an error causes the stream to emit a done event", () {
-      expect(channel.sink.done, throwsA("oh no"));
+    test('adding an error causes the stream to emit a done event', () {
+      expect(channel.sink.done, throwsA('oh no'));
 
       streamController.add(1);
       streamController.add(2);
@@ -165,21 +165,21 @@ void main() {
       expect(
           channel.stream
               .listen(expectAsync1((event) {
-                if (event == 2) channel.sink.addError("oh no");
+                if (event == 2) channel.sink.addError('oh no');
               }, count: 2))
               .asFuture(),
           completes);
     });
 
-    test("adding an error closes the inner sink", () {
-      channel.sink.addError("oh no");
-      expect(channel.sink.done, throwsA("oh no"));
+    test('adding an error closes the inner sink', () {
+      channel.sink.addError('oh no');
+      expect(channel.sink.done, throwsA('oh no'));
       expect(sinkController.stream.toList(), completion(isEmpty));
     });
 
     test(
-        "adding an error via via addStream causes the stream to emit a done "
-        "event", () async {
+        'adding an error via via addStream causes the stream to emit a done '
+        'event', () async {
       var canceled = false;
       var controller = StreamController(onCancel: () {
         canceled = true;
@@ -188,8 +188,8 @@ void main() {
       // This future shouldn't get the error, because it's sent to [Sink.done].
       expect(channel.sink.addStream(controller.stream), completes);
 
-      controller.addError("oh no");
-      expect(channel.sink.done, throwsA("oh no"));
+      controller.addError('oh no');
+      expect(channel.sink.done, throwsA('oh no'));
       await pumpEventQueue();
       expect(canceled, isTrue);
 


### PR DESCRIPTION
- use_function_type_syntax_for_parameters
- prefer_single_quotes