### PR TITLE
Close send channel in test

### DIFF
--- a/test/isolate_channel_test.dart
+++ b/test/isolate_channel_test.dart
@@ -137,19 +137,21 @@ void main() {
       connectPort.close();
     });
 
-    test('create a connected pair of channels', () {
+    test('create a connected pair of channels', () async {
       var channel1 = IsolateChannel<int>.connectReceive(connectPort);
       var channel2 = IsolateChannel<int>.connectSend(connectPort.sendPort);
 
       channel1.sink.add(1);
       channel1.sink.add(2);
       channel1.sink.add(3);
-      expect(channel2.stream.take(3).toList(), completion(equals([1, 2, 3])));
+      expect(await channel2.stream.take(3).toList(), equals([1, 2, 3]));
 
       channel2.sink.add(4);
       channel2.sink.add(5);
       channel2.sink.add(6);
-      expect(channel1.stream.take(3).toList(), completion(equals([4, 5, 6])));
+      expect(await channel1.stream.take(3).toList(), equals([4, 5, 6]));
+
+      await channel2.sink.close();
     });
 
     test('the receiving channel produces an error if it gets the wrong message',


### PR DESCRIPTION
Without closing this channel the VM will not exit. Refactor to
`async/await` so that we can close the channel only after receiving the
expected items. This allows running the test directly in the VM without
the test runner.