### PR TITLE
Remove the author section from pubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.1.0-nullsafety.1-dev
+
 ## 2.1.0-nullsafety
 
 * Migrate to null safety.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,9 @@
 name: stream_channel
-version: 2.1.0-nullsafety
+version: 2.1.0-nullsafety.1-dev
 
 description: >-
   An abstraction for two-way communication channels based on the Dart Stream
   class.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/stream_channel
 
 environment:


### PR DESCRIPTION
Resolves a warning from the pub tool that this field is no longer used.