### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.1.0-nullsafety.1-dev
+## 2.1.0-nullsafety.1
+
+* Allow 2.10 stable and 2.11.0 dev SDK versions.
 
 ## 2.1.0-nullsafety
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stream_channel
-version: 2.1.0-nullsafety.1-dev
+version: 2.1.0-nullsafety.1
 
 description: >-
   An abstraction for two-way communication channels based on the Dart Stream
@@ -8,7 +8,7 @@ homepage: https://github.com/dart-lang/stream_channel
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   async: '>=2.5.0-nullsafety <2.5.0'


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.