### PR TITLE
Remove unused dart:async import

### DIFF
--- a/lib/src/stream_channel_completer.dart
+++ b/lib/src/stream_channel_completer.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:async/async.dart';
 
 import '../stream_channel.dart';


### PR DESCRIPTION
The only members of dart:async used here (Future and/or Stream) are exported from dart:core now.