### PR TITLE
Handle non-int multichannel message IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Require Dart 2.14
 * Migrate to `package:lints`.
 * Populate the pubspec `repository` field.
+* Handle multichannel messages where the ID element is a `double` at runtime
+  instead of an `int`. When reading an array with `dart2wasm` numbers within the
+  array are parsed as `double`.
 
 ## 2.1.0
 

--- a/lib/src/multi_channel.dart
+++ b/lib/src/multi_channel.dart
@@ -141,7 +141,7 @@ class _MultiChannel<T> extends StreamChannelMixin<T>
         onDone: () => _closeChannel(0, 0));
 
     _innerStreamSubscription = _inner!.stream.cast<List>().listen((message) {
-      var id = message[0] as int;
+      var id = (message[0] as num).toInt();
 
       // If the channel was closed before an incoming message was processed,
       // ignore that message.


### PR DESCRIPTION
When running in wasm, a number in a `List` will be parsed as a `double`. On the web the `as int` cast succeeds, but in dart2wasm it fails. Cast to `num` and use `toInt()` to more reliably get an `int` value.